### PR TITLE
Update CMakeList.txt to use x.h instead of win.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(${FC_INCLUDE_DIRS} ${FT_INCLUDE_DIRS})
 link_directories(${FC_LBIRARY_DIRS} ${FT_LIBRARY_DIRS})
 add_compile_options(${FC_CFLAGS} ${FT_CFLAGS})
 
-add_executable(mt mt.c arg.h config.h mt.h win.h x.c)
+add_executable(mt mt.c arg.h config.h mt.h x.h x.c)
 target_link_libraries(mt -lm -lrt -lutil
                       ${X11_LIBRARIES} ${X11_Xft_LIB}
                       ${FC_LIBRARIES} ${FT_LIBRARIES})


### PR DESCRIPTION
There is no longer a file win.h so the project currently does not build.  This fix corrects that.

And FWIW I just signed the CLA too.