### PR TITLE
Improve documentation in config.h (NFC)

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,216 +1,172 @@
-/*
- * appearance
- *
- * font: see http://freedesktop.org/software/fontconfig/fontconfig-user.html
- */
+// Font specification in fontconfig format.
+// See http://freedesktop.org/software/fontconfig/fontconfig-user.html
 char font[] = "Roboto Mono for Powerline:size=9:antialias=true:autohint=true";
+
+// Margin between window edges and console area.
 int borderpx = 2;
 
-/*
- * What program is execed by st depends of these precedence rules:
- * 1: program passed with -e
- * 2: utmp option
- * 3: SHELL environment variable
- * 4: value of shell in /etc/passwd
- * 5: value of shell in config.h
- */
+// Shell program to run when mt starts.
+// The following sources are consulted in order:
+//   1. program passed with -e
+//   2. the `utmp` option
+//   3. POSIX $SHELL environment variable
+//   4. user's shell in /etc/passwd
+//   5. the `shell` option
 static char shell[] = "/bin/sh";
 static char *utmp = NULL;
+
+// Base stty command for configuring an external tty line.
+// This is used when `-l device` is used instead of opening a pseudoterminal.
+// Any extra command-line arguments are appended.
 static char stty_args[] = "stty raw pass8 nl -echo -iexten -cstopb 38400";
 
-/* identification sequence returned in DA and DECID */
+// Identification sequence returned in response to an ANSI [c escape code.
+// The default value identifies as a VT102.
 static char vtiden[] = "\033[?6c";
 
-/* Kerning / character bounding-box multipliers */
+// Kerning / character bounding-box multipliers.
 float cwscale = 1.0;
 float chscale = 1.0;
 
-/*
- * word delimiter string
- *
- * More advanced example: " `'\"()[]{}"
- */
+// Characters that separate words.
+// This affects text selection.
 static char worddelimiters[] = " ";
 
-/* selection timeouts (in milliseconds) */
+// Timeouts for selection gestures, in milliseconds.
 unsigned int doubleclicktimeout = 300;
 unsigned int tripleclicktimeout = 600;
 
-/* alt screens */
+// Enable the "alternate screen" feature?
+// This allows fullscreen editors etc to restore the screen contents on exit.
 int allowaltscreen = 1;
 
-/* frames per second st should at maximum draw to the screen */
+// Maximum redraw rate for events triggered by the UI (keystrokes, mouse).
 unsigned int xfps = 120;
+// Maximum redraw rate for events triggered by the terminal (program output).
 unsigned int actionfps = 30;
 
-/*
- * blinking timeout (set to 0 to disable blinking) for the terminal blinking
- * attribute.
- */
+// Blink period in ms, for text with the blinking attribute.
+// 0 disables blinking.
 unsigned int blinktimeout = 800;
 
-/*
- * thickness of underline and bar cursors
- */
+// Width of the underline and vertical bar cursors, in pixels.
 unsigned int cursorthickness = 2;
 
-/*
- * bell volume. It must be a value between -100 and 100. Use 0 for disabling
- * it
- */
+// Volume of bell (^G).
+// If zero, the bell is disabled.
+// Otherwise the volume is passed to XBell():
+//   -100 to -1 is the range from silent to base volume
+//   1 to 100 is the range from base to max volume
 static int bellvolume = 0;
 
-/* default TERM value */
+// Value of the $TERM variable.
 char termname[] = "xterm-256color";
 
-/*
- * spaces per tab
- *
- * When you are changing this value, don't forget to adapt the »it« value in
- * the st.info and appropriately install the st.info in the environment where
- * you use this st version.
- *
- *  it#$tabspaces,
- *
- * Secondly make sure your kernel is not expanding tabs. When running `stty
- * -a` »tab0« should appear. You can tell the terminal to not expand tabs by
- *  running following command:
- *
- *  stty tabs
- */
+// Tab width.
+// Changing this requires modifying the terminfo database.
 static unsigned int tabspaces = 8;
 
-/* Terminal colors (16 first used in escape sequence) */
+// Available terminal colors (X color names, or #123abc hex codes).
+// Basic colors (required):
+//  0-7:     basic colors - black, red, green, yellow, blue, magenta, cyan, grey
+//  8-15:    bright versions of the above colors
+// RGB colors (default to conventional values):
+//  16-231:  RGB colors (6 levels of each)
+//  232-255: additional shades of grey
+// Additional colors (optional):
+//  256+:    colors not accessible to applications (cursor colors etc)
 const char *colorname[] = {
-    /* 8 normal colors */
-    "black", "red3", "green3", "yellow3", "blue2", "magenta3", "cyan3",
-    "gray90",
+    "black", "red3", "green3", "yellow3",
+    "blue2", "magenta3", "cyan3", "gray90",
 
-    /* 8 bright colors */
-    "gray50", "red", "green", "yellow", "#5c5cff", "magenta", "cyan", "white",
+    "gray50", "red", "green", "yellow",
+    "#5c5cff", "magenta", "cyan", "white",
 
     [255] = 0,
 
-    /* more colors can be added after 255 to use with DefaultXX */
     "#cccccc", "#555555",
 };
 
-/*
- * Default colors (colorname index)
- * foreground, background, cursor, reverse cursor
- */
+// Default foreground and background colors.
 unsigned int defaultfg = 7;
 unsigned int defaultbg = 0;
+
+// Cursor color.
 unsigned int defaultcs = 256;
+// Cursor color in reverse mode and when selecting.
 unsigned int defaultrcs = 257;
 
-/*
- * Default shape of cursor
- * 2: Block ("█")
- * 4: Underline ("_")
- * 6: Bar ("|")
- * 7: Snowman ("☃")
- */
+// Default shape of cursor.
+//  0-2: Block ("█")
+//  3-4: Underline ("_")
+//  5-6: Bar ("|")
+//  7: Snowman ("☃")
+// 0, 1, 3, 5 are desinated blinking variants, but blinking is not implemented.
 unsigned int cursorshape = 2;
 
-/*
- * Default columns and rows numbers
- */
-
+// Default terminal window size.
 unsigned int cols = 80;
 unsigned int rows = 24;
 
-/*
- * Default colour and shape of the mouse cursor
- */
+// Default colour and shape of the mouse cursor.
 unsigned int mouseshape = XC_xterm;
 unsigned int mousefg = 7;
 unsigned int mousebg = 0;
 
-/*
- * Color used to display font attributes when fontconfig selected a font which
- * doesn't match the ones requested.
- */
+// Color indicating the active style (bold, italic) isn't supported by the font.
 unsigned int defaultattr = 11;
 
-/*
- * Internal mouse shortcuts.
- * Beware that overloading Button1 will disable the selection.
- */
+// Mouse shortcuts.
+// The default values map the scroll wheel (Button4/5) to ^Y/^E (vim commands).
+// Note that mapping Button1 will interfere with selection.
 MouseShortcut mshortcuts[] = {
   /* button               mask            string */
   { Button4,              XK_ANY_MOD,     "\031" },
   { Button5,              XK_ANY_MOD,     "\005" },
 };
 
-/* Internal keyboard shortcuts. */
-#define MODKEY Mod1Mask
-#define TERMMOD (ControlMask | ShiftMask)
-
+// Keyboard shortcuts that trigger internal functions.
 Shortcut shortcuts[] = {
-  /* mask                 keysym          function        argument */
-  { XK_ANY_MOD,           XK_Break,       sendbreak,      {.i =  0} },
-  { ControlMask,          XK_Print,       toggleprinter,  {.i =  0} },
-  { ShiftMask,            XK_Print,       printscreen,    {.i =  0} },
-  { XK_ANY_MOD,           XK_Print,       printsel,       {.i =  0} },
-  { TERMMOD,              XK_Prior,       zoom,           {.f = +1} },
-  { TERMMOD,              XK_Next,        zoom,           {.f = -1} },
-  { TERMMOD,              XK_Home,        zoomreset,      {.f =  0} },
-  { TERMMOD,              XK_C,           clipcopy,       {.i =  0} },
-  { TERMMOD,              XK_V,           clippaste,      {.i =  0} },
-  { TERMMOD,              XK_Y,           selpaste,       {.i =  0} },
-  { TERMMOD,              XK_Num_Lock,    numlock,        {.i =  0} },
-  { TERMMOD,              XK_I,           iso14755,       {.i =  0} },
+  /* mask                       keysym          function        argument */
+  { XK_ANY_MOD,                 XK_Break,       sendbreak,      {.i =  0} },
+  { ControlMask,                XK_Print,       toggleprinter,  {.i =  0} },
+  { ShiftMask,                  XK_Print,       printscreen,    {.i =  0} },
+  { XK_ANY_MOD,                 XK_Print,       printsel,       {.i =  0} },
+  { (ControlMask | ShiftMask),  XK_Prior,       zoom,           {.f = +1} },
+  { (ControlMask | ShiftMask),  XK_Next,        zoom,           {.f = -1} },
+  { (ControlMask | ShiftMask),  XK_Home,        zoomreset,      {.f =  0} },
+  { (ControlMask | ShiftMask),  XK_C,           clipcopy,       {.i =  0} },
+  { (ControlMask | ShiftMask),  XK_V,           clippaste,      {.i =  0} },
+  { (ControlMask | ShiftMask),  XK_Y,           selpaste,       {.i =  0} },
+  { (ControlMask | ShiftMask),  XK_Num_Lock,    numlock,        {.i =  0} },
+  { (ControlMask | ShiftMask),  XK_I,           iso14755,       {.i =  0} },
 };
 
-/*
- * Special keys (change & recompile st.info accordingly)
- *
- * Mask value:
- * * Use XK_ANY_MOD to match the key no matter modifiers state
- * * Use XK_NO_MOD to match the key alone (no modifiers)
- * appkey value:
- * * 0: no value
- * * > 0: keypad application mode enabled
- * *   = 2: term.numlock = 1
- * * < 0: keypad application mode disabled
- * appcursor value:
- * * 0: no value
- * * > 0: cursor application mode enabled
- * * < 0: cursor application mode disabled
- * crlf value
- * * 0: no value
- * * > 0: crlf mode is enabled
- * * < 0: crlf mode is disabled
- *
- * Be careful with the order of the definitions because st searches in
- * this table sequentially, so any XK_ANY_MOD must be in the last
- * position for a key.
- */
-
-/*
- * If you want keys other than the X11 function keys (0xFD00 - 0xFFFF)
- * to be mapped below, add them to this array.
- */
+// Keys outside the X11 function key range (0xFD00 - 0xFFFF) with shortcuts.
+// By default, shortcuts in `key` are only scanned for KeySyms in this range.
 static KeySym mappedkeys[] = {-1};
 
-/*
- * State bits to ignore when matching key or button events.  By default,
- * numlock (Mod2Mask) and keyboard layout (XK_SWITCH_MOD) are ignored.
- */
+// Modifiers to ignore when matching keyboard and mouse events.
+// By default, numlock and keyboard layout are ignored.
 static uint ignoremod = Mod2Mask | XK_SWITCH_MOD;
 
-/*
- * Override mouse-select while mask is active (when MODE_MOUSE is set).
- * Note that if you want to use ShiftMask with selmasks, set this to an other
- * modifier, set to 0 to not use it.
- */
+// Keyboard modifier to force mouse selection when in mouse mode.
+// This lets you select text even if the application has captured the mouse.
 uint forceselmod = ShiftMask;
 
-/*
- * This is the huge key array which defines all compatibility to the Linux
- * world. Please decide about changes wisely.
- */
+// Keyboard shortcuts that send bytes to the terminal.
+// The first entry whose critera match the key event is chosen.
+//
+// Some criteria match against the current mode:
+//   `appkey` is linked to whether the keypad is in "application mode"
+//   `appcursor` is linked to whether cursor keys are in "application mode"
+//   `crlf` is linked to whether the terminal is in "automatic newline mode"
+// These have three values
+//   -1: only match if mode is NOT active
+//   0 : match independent of mode
+//   1 : only match if mode is active
+// appkey has one extra value:
+//   2 : only match if mode is active AND numlock was toggled off.
 static Key key[] = {
   /* keysym           mask            string      appkey appcursor crlf */
   { XK_KP_Home,       ShiftMask,      "\033[1;2H",     0,    0,    0},
@@ -412,21 +368,14 @@ static Key key[] = {
   { XK_F35,           XK_NO_MOD,      "\033[23;5~",    0,    0,    0},
 };
 
-/*
- * Selection types' masks.
- * Use the same masks as usual.
- * Button1Mask is always unset, to make masks match between ButtonPress.
- * ButtonRelease and MotionNotify.
- * If no match is found, regular selection is used.
- */
+// Keyboard modifiers that alter the behavior of mouse selection.
+// If no match is found, regular selection is used.
 uint selmasks[] = {
         [SEL_RECTANGULAR] = Mod1Mask,
 };
 
-/*
- * Printable characters in ASCII, used to estimate the advance width
- * of single wide characters.
- */
+// Printable characters in ASCII.
+// Used to calculate the average character width in a font.
 char ascii_printable[] = " !\"#$%&'()*+,-./0123456789:;<=>?"
                          "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
                          "`abcdefghijklmnopqrstuvwxyz{|}~";


### PR DESCRIPTION
Adjusted comments that were missing, poorly worded, overly obscure, or
otherwise unhelpful to users. Some research was required!

Removed macros that were unused/trivially used.

Switched /* C comments */ to // line-comments.

Resisted the urge to reorder, rename, and remove options, to keep the
diff small.