### PR TITLE
Configure shell in a more obvious way.

### DIFF
--- a/config.h
+++ b/config.h
@@ -9,13 +9,12 @@ int borderpx = 2;
 /*
  * What program is execed by st depends of these precedence rules:
  * 1: program passed with -e
- * 2: utmp option
+ * 2: shell option
  * 3: SHELL environment variable
  * 4: value of shell in /etc/passwd
- * 5: value of shell in config.h
+ * 5: /bin/sh
  */
-static char shell[] = "/bin/sh";
-static char *utmp = NULL;
+static char *shell = NULL;
 static char stty_args[] = "stty raw pass8 nl -echo -iexten -cstopb 38400";
 
 /* identification sequence returned in DA and DECID */

--- a/mt.c
+++ b/mt.c
@@ -622,7 +622,7 @@ void execsh(void) {
     sh = "/bin/sh";
   }
 
-  // The program to execute is $SHELL unless explicitly specified.
+  // The program to execute is the shell unless explicitly specified.
   char **args, *prog;
   if (opt_cmd) {
     prog = opt_cmd[0];

--- a/mt.c
+++ b/mt.c
@@ -601,9 +601,8 @@ void die(const char *errstr, ...) {
 }
 
 void execsh(void) {
-  char **args, *sh, *prog;
+  // Read user info from passwd file.
   const struct passwd *pw;
-
   errno = 0;
   if ((pw = getpwuid(getuid())) == NULL) {
     if (errno)
@@ -612,16 +611,26 @@ void execsh(void) {
       die("who are you?\n");
   }
 
-  if ((sh = getenv("SHELL")) == NULL)
-    sh = (pw->pw_shell[0]) ? pw->pw_shell : shell;
+  // Find user's preferred shell. This will become $SHELL.
+  char *sh;
+  if (shell != NULL) {
+    sh = shell;
+  } else if ((sh = getenv("SHELL")) != NULL) {
+  } else if (pw->pw_shell[0]) {
+    sh = pw->pw_shell;
+  } else {
+    sh = "/bin/sh";
+  }
 
-  if (opt_cmd)
+  // The program to execute is $SHELL unless explicitly specified.
+  char **args, *prog;
+  if (opt_cmd) {
     prog = opt_cmd[0];
-  else if (utmp)
-    prog = utmp;
-  else
+    args = opt_cmd;
+  } else {
     prog = sh;
-  args = (opt_cmd) ? opt_cmd : (char *[]){prog, NULL};
+    args = (char *[]){prog, NULL};
+  }
 
   unsetenv("COLUMNS");
   unsetenv("LINES");


### PR DESCRIPTION
Provide a single configuration option: higher priority than system
config, lower than -c. This is similar to the old utmp, but without the
weird name and the sucklessism that utmp never became $SHELL (because it
is a helper program).

Hardcode the /bin/sh fallback when detecting preferred shell fails.

Spend a few more lines to make the fallback sequence (IMO) less cryptic.