### PR TITLE
Make ascii_printable non-configurable.

### DIFF
--- a/config.h
+++ b/config.h
@@ -423,11 +423,3 @@ uint selmasks[] = {
         [SEL_RECTANGULAR] = Mod1Mask,
 };
 
-/*
- * Printable characters in ASCII, used to estimate the advance width
- * of single wide characters.
- */
-char ascii_printable[] = " !\"#$%&'()*+,-./0123456789:;<=>?"
-                         "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
-                         "`abcdefghijklmnopqrstuvwxyz{|}~";
-

--- a/mt.h
+++ b/mt.h
@@ -263,6 +263,5 @@ extern size_t shortcutslen;
 extern uint forceselmod;
 extern uint selmasks[];
 extern size_t selmaskslen;
-extern char ascii_printable[];
 
 #endif

--- a/x.c
+++ b/x.c
@@ -679,6 +679,11 @@ int xloadfont(MTFont *f, FcPattern *pattern) {
     }
   }
 
+  // We take font width as the average of these characters.
+  static char ascii_printable[] =
+      " !\"#$%&'()*+,-./0123456789:;<=>?"
+      "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
+      "`abcdefghijklmnopqrstuvwxyz{|}~";
   XftTextExtentsUtf8(xw.dpy, f->match, (const FcChar8 *)ascii_printable,
                      strlen(ascii_printable), &extents);
 


### PR DESCRIPTION
This determines the set of characters used to estimate font width.
I can't see any reason a user would change this.