### PR TITLE
Make identifier(DECTID/DA1) string non-configurable.

### DIFF
--- a/config.h
+++ b/config.h
@@ -18,9 +18,6 @@ static char shell[] = "/bin/sh";
 static char *utmp = NULL;
 static char stty_args[] = "stty raw pass8 nl -echo -iexten -cstopb 38400";
 
-/* identification sequence returned in DA and DECID */
-static char vtiden[] = "\033[?6c";
-
 /* Kerning / character bounding-box multipliers */
 float cwscale = 1.0;
 float chscale = 1.0;

--- a/mt.c
+++ b/mt.c
@@ -231,6 +231,10 @@ size_t mshortcutslen = LEN(mshortcuts);
 size_t shortcutslen = LEN(shortcuts);
 size_t selmaskslen = LEN(selmasks);
 
+// Identification sequence returned in DA and DECID.
+// We claim to be a VT102, feature detection is via terminfo in practice.
+static char vt102_identify[] = "\033[?6c";
+
 ssize_t xwrite(int fd, const char *s, size_t len) {
   size_t aux = len;
   ssize_t r;
@@ -1497,7 +1501,7 @@ void csihandle(void) {
     break;
   case 'c': /* DA -- Device Attributes */
     if (csiescseq.arg[0] == 0)
-      ttywrite(vtiden, sizeof(vtiden) - 1);
+      ttywrite(vt102_identify, strlen(vt102_identify));
     break;
   case 'C': /* CUF -- Cursor <n> Forward */
   case 'a': /* HPR -- Cursor <n> Forward */
@@ -2023,7 +2027,7 @@ void tcontrolcode(uchar ascii) {
   case 0x99: /* TODO: SGCI */
     break;
   case 0x9a: /* DECID -- Identify Terminal */
-    ttywrite(vtiden, sizeof(vtiden) - 1);
+    ttywrite(vt102_identify, strlen(vt102_identify));
     break;
   case 0x9b: /* TODO: CSI */
   case 0x9c: /* TODO: ST */
@@ -2093,7 +2097,7 @@ int eschandle(uchar ascii) {
     }
     break;
   case 'Z': /* DECID -- Identify Terminal */
-    ttywrite(vtiden, sizeof(vtiden) - 1);
+    ttywrite(vt102_identify, strlen(vt102_identify));
     break;
   case 'c': /* RIS -- Reset to inital state */
     treset();


### PR DESCRIPTION
It's hard to see compelling use cases: most software will assume
vt102+terminfo anyway.

But even if this should be configurable, configuring the ident string
directly isn't the right mechanism - it should be coupled to configuring
the reported features.