### PR TITLE
Don't support direct configuration of bell volume.

### DIFF
--- a/config.h
+++ b/config.h
@@ -54,11 +54,9 @@ unsigned int blinktimeout = 800;
  */
 unsigned int cursorthickness = 2;
 
-/*
- * bell volume. It must be a value between -100 and 100. Use 0 for disabling
- * it
- */
-static int bellvolume = 0;
+// Ring the bell for the ^G character.
+// XkbBell() is used, the volume can be controlled with xset.
+static int bell = 0;
 
 /* default TERM value */
 char termname[] = "xterm-256color";

--- a/mt.c
+++ b/mt.c
@@ -1966,8 +1966,8 @@ void tcontrolcode(uchar ascii) {
     } else {
       if (!(win.state & WIN_FOCUSED))
         xseturgency(1);
-      if (bellvolume)
-        xbell(bellvolume);
+      if (bell)
+        xbell();
     }
     break;
   case '\033': /* ESC */

--- a/x.c
+++ b/x.c
@@ -1335,7 +1335,7 @@ void xseturgency(int add) {
   XFree(h);
 }
 
-void xbell(int vol) { XkbBell(xw.dpy, xw.win, vol, (Atom)NULL); }
+void xbell(void) { XkbBell(xw.dpy, xw.win, 0, (Atom)NULL); }
 
 unsigned long xwinid(void) { return xw.win; }
 

--- a/x.h
+++ b/x.h
@@ -12,7 +12,7 @@ void draw(void);
 void drawregion(int, int, int, int);
 void run(void);
 
-void xbell(int);
+void xbell(void);
 void xclipcopy(void);
 void xclippaste(void);
 void xhints(void);


### PR DESCRIPTION
The X keyboard bell has a configurable volume, and terminal emulators are
basically the only applications that use it these days.

There's an argument it's simpler for the user to configure it here, but:

  - the volume scale used by XkbBell() is confusing (a piecewise linear
    function of "relative percent"). xset works in the obvious way.
  - conflating on/off and volume is confusing, since zero is a valid
    XkbBell volume (and in fact is the most sensible bell-on default!)

Alternatives are:

  - remove all configuration, always ring the bell, the user can silence it.
    This seems extreme, and would make the bell on-by-default.
  - configure enabled and volume separately. YAGNI, though.