### PR TITLE
Remove tabspaces config flag, in favor of dynamic tabstop management.

### DIFF
--- a/config.h
+++ b/config.h
@@ -63,23 +63,6 @@ static int bellvolume = 0;
 /* default TERM value */
 char termname[] = "xterm-256color";
 
-/*
- * spaces per tab
- *
- * When you are changing this value, don't forget to adapt the »it« value in
- * the st.info and appropriately install the st.info in the environment where
- * you use this st version.
- *
- *  it#$tabspaces,
- *
- * Secondly make sure your kernel is not expanding tabs. When running `stty
- * -a` »tab0« should appear. You can tell the terminal to not expand tabs by
- *  running following command:
- *
- *  stty tabs
- */
-static unsigned int tabspaces = 8;
-
 /* Terminal colors (16 first used in escape sequence) */
 const char *colorname[] = {
     /* 8 normal colors */


### PR DESCRIPTION
The initial tabstops state is described by terminfo, so this setting
could not be effectively used without modifying terminfo.

Programs can set the terminal tabstops, e.g. the POSIX `tabs`
command, which is the typical way to adjust this behavior.

Configuring `tabspaces` have one advantage: because it's an interval rather
than a list of columns, it's clear where to insert new tabstops if the
terminal is widened.

I simulate this by inferring the width from the first tabstop, which
will do the right thing if tabs have uniform width.

Various terminals' behavior when widening after `tabs 4`:

  - mt previously added new tabstops 8 apart
  - urxvt resets all tabs to 8 wide
  - xterm+gnome-terminal make tabs past the old width wrap onto a new line