### PR TITLE
Mostly revert d7ff9721: backspace sends DEL again.

### DIFF
--- a/config.h
+++ b/config.h
@@ -312,7 +312,7 @@ static Key key[] = {
   { XK_Delete,        ControlMask,    "\033[3;5~",     0,    0,    0},
   { XK_Delete,        ShiftMask,      "\033[3;2~",     0,    0,    0},
   { XK_Delete,        XK_ANY_MOD,     "\033[3~",       0,    0,    0},
-  { XK_BackSpace,     XK_ANY_MOD,     "\010",          0,    0,    0},
+  { XK_BackSpace,     XK_ANY_MOD,     "\177",          0,    0,    0},
   { XK_Home,          ShiftMask,      "\033[1;2H",     0,    0,    0},
   { XK_Home,          XK_ANY_MOD,     "\033OH",        0,    0,    0},
   { XK_End,           ControlMask,    "\033[1;5F",     0,    0,    0},

--- a/xterm-emulation-terminfo.info
+++ b/xterm-emulation-terminfo.info
@@ -89,7 +89,8 @@ xterm-256color| Generic terminfo settings that are largely xterm compatible.
   ka3=\E[5~, # st
   # xterm: kb2=\EOE,
   kb2=\EOu,
-  kbs=^H,
+  # xterm: kbs=^H, (but most linux distributions change this to \177)
+  kbs=\177,
   kc1=\E[4~, # st
   kc3=\E[6~, # st
   kcbt=\E[Z,

--- a/xterm-emulation-terminfo.info
+++ b/xterm-emulation-terminfo.info
@@ -89,7 +89,9 @@ xterm-256color| Generic terminfo settings that are largely xterm compatible.
   ka3=\E[5~, # st
   # xterm: kb2=\EOE,
   kb2=\EOu,
-  # xterm: kbs=^H, (but most linux distributions change this to \177)
+  # xterm: kbs=^H
+  # Most linux distributions change this to kbs=\177.
+  # On Mac, this is ^H but terminals ignore it and send \177.
   kbs=\177,
   kc1=\E[4~, # st
   kc3=\E[6~, # st


### PR DESCRIPTION
The previous commit made backspace send ^H, for consistency with xterm's
terminfo. Unfortunately this broke backspace on my laptop.

It turns out xterm's terminfo itself is not consistent across systems:
`infocmp xterm | grep kbs` reports `\177` on my ubuntu machines.

This matches [debian's policy](https://www.debian.org/doc/debian-policy/ch-opersys.html#s9.8) which [redhat also followed](https://bugzilla.redhat.com/show_bug.cgi?id=142659) (10 years ago, but I bet it's still the same).

On the other hand, some distros (e.g. Arch) and non-linuxes use `^H`. The upstream sources have [a pretty sad comment on this](http://invisible-island.net/xterm/terminfo-contents.html#tic-xterm_kbs).

I can't explain why it works on some systems even with the "wrong" string, but maybe we can lean on that for now?

I think the correct fix is for mt to read the terminfo database and do
what it says, left a TODO for now. This is easier once defaults are separated from user settings, I think.