### PR TITLE
Remove serial line support

### DIFF
--- a/config.h
+++ b/config.h
@@ -16,7 +16,6 @@ int borderpx = 2;
  */
 static char shell[] = "/bin/sh";
 static char *utmp = NULL;
-static char stty_args[] = "stty raw pass8 nl -echo -iexten -cstopb 38400";
 
 /* identification sequence returned in DA and DECID */
 static char vtiden[] = "\033[?6c";

--- a/mt.c
+++ b/mt.c
@@ -136,7 +136,6 @@ static void sendbreak(const Arg *);
 #include "config.h"
 
 static void execsh(void);
-static void stty(void);
 static void sigchld(int);
 
 static void csidump(void);
@@ -207,7 +206,6 @@ char *opt_class = NULL;
 char *opt_embed = NULL;
 char *opt_font = NULL;
 char *opt_io = NULL;
-char *opt_line = NULL;
 char *opt_name = NULL;
 char *opt_title = NULL;
 int oldbutton = 3; /* button event on startup: 3 = release */
@@ -659,28 +657,6 @@ void sigchld(int a) {
   exit(0);
 }
 
-void stty(void) {
-  char cmd[_POSIX_ARG_MAX], **p, *q, *s;
-  size_t n, siz;
-
-  if ((n = strlen(stty_args)) > sizeof(cmd) - 1)
-    die("incorrect stty parameters\n");
-  memcpy(cmd, stty_args, n);
-  q = cmd + n;
-  siz = sizeof(cmd) - n;
-  for (p = opt_cmd; p && (s = *p); ++p) {
-    if ((n = strlen(s)) > siz - 1)
-      die("stty parameter length too long\n");
-    *q++ = ' ';
-    memcpy(q, s, n);
-    q += n;
-    siz -= n + 1;
-  }
-  *q = '\0';
-  if (system(cmd) != 0)
-    perror("Couldn't call stty");
-}
-
 void ttynew(void) {
   int m, s;
   struct winsize w = {term.row, term.col, 0, 0};
@@ -691,14 +667,6 @@ void ttynew(void) {
     if (iofd < 0) {
       fprintf(stderr, "Error opening %s:%s\n", opt_io, strerror(errno));
     }
-  }
-
-  if (opt_line) {
-    if ((cmdfd = open(opt_line, O_RDWR)) < 0)
-      die("open line failed: %s\n", strerror(errno));
-    dup2(cmdfd, 0);
-    stty();
-    return;
   }
 
   /* seems to work fine on linux, openbsd and freebsd */
@@ -2443,10 +2411,6 @@ void usage(void) {
   die("usage: %s [-aiv] [-c class] [-f font] [-g geometry]"
       " [-n name] [-o file]\n"
       "          [-T title] [-t title] [-w windowid]"
-      " [[-e] command [args ...]]\n"
-      "       %s [-aiv] [-c class] [-f font] [-g geometry]"
-      " [-n name] [-o file]\n"
-      "          [-T title] [-t title] [-w windowid] -l line"
-      " [stty_args ...]\n",
-      argv0, argv0);
+      " [[-e] command [args ...]]\n",
+      argv0);
 }

--- a/mt.h
+++ b/mt.h
@@ -221,7 +221,6 @@ extern char *opt_class;
 extern char *opt_embed;
 extern char *opt_font;
 extern char *opt_io;
-extern char *opt_line;
 extern char *opt_name;
 extern char *opt_title;
 extern int oldbutton;

--- a/x.c
+++ b/x.c
@@ -1562,9 +1562,6 @@ int main(int argc, char *argv[]) {
   case 'o':
     opt_io = EARGF(usage());
     break;
-  case 'l':
-    opt_line = EARGF(usage());
-    break;
   case 'n':
     opt_name = EARGF(usage());
     break;
@@ -1587,7 +1584,7 @@ run:
   if (argc > 0) {
     /* eat all remaining arguments */
     opt_cmd = argv;
-    if (!opt_title && !opt_line)
+    if (!opt_title)
       opt_title = basename(xstrdup(argv[0]));
   }
   setlocale(LC_CTYPE, "");


### PR DESCRIPTION
  - connecting directly to a serial line is a niche use case
  - the alternatives (`-e cu` ... or `-e screen` ...) seem pretty easy
  - the `stty_args` configuration is weird (baud rate as a program-level option!)