### PR TITLE
Build as C++ rather than C.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required (VERSION 3.5)
-project (mt C CXX)
+project (mt CXX)
 
-add_compile_options(-std=c99 -pedantic -Wall)
+# FIXME: clean up signed/unsigned comparisons and enable the warning.
+add_compile_options(-std=c++11 -pedantic -Wall -Werror -Wno-sign-compare)
 add_definitions(-DVERSION=\"0.1\" -D_XOPEN_SOURCE=600)
 
 find_package(X11 REQUIRED)
@@ -14,7 +15,7 @@ include_directories(${FC_INCLUDE_DIRS} ${FT_INCLUDE_DIRS})
 link_directories(${FC_LBIRARY_DIRS} ${FT_LIBRARY_DIRS})
 add_compile_options(${FC_CFLAGS} ${FT_CFLAGS})
 
-add_executable(mt mt.c arg.h config.h mt.h x.h x.c)
+add_executable(mt mt.cc arg.h config.h mt.h x.h x.cc)
 target_link_libraries(mt -lm -lrt -lutil
                       ${X11_LIBRARIES} ${X11_Xft_LIB}
                       ${FC_LIBRARIES} ${FT_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ the Ninja generator of CMake is encouraged.
 
 ## Cleanup
 
-- Switch to C++
-- Use C++ to simplify any constructs.
+- Use C++ to simplify any constructs from the old C code.
 - Identify any existing libraries that can be used effectively.
 - Factor code into libraries and write unittests.
 

--- a/config.h
+++ b/config.h
@@ -89,7 +89,37 @@ const char *colorname[] = {
     /* 8 bright colors */
     "gray50", "red", "green", "yellow", "#5c5cff", "magenta", "cyan", "white",
 
-    [255] = 0,
+    // FIXME: this is silly.
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
 
     /* more colors can be added after 255 to use with DefaultXX */
     "#cccccc", "#555555",
@@ -149,18 +179,18 @@ MouseShortcut mshortcuts[] = {
 
 Shortcut shortcuts[] = {
   /* mask                 keysym          function        argument */
-  { XK_ANY_MOD,           XK_Break,       sendbreak,      {.i =  0} },
-  { ControlMask,          XK_Print,       toggleprinter,  {.i =  0} },
-  { ShiftMask,            XK_Print,       printscreen,    {.i =  0} },
-  { XK_ANY_MOD,           XK_Print,       printsel,       {.i =  0} },
-  { TERMMOD,              XK_Prior,       zoom,           {.f = +1} },
-  { TERMMOD,              XK_Next,        zoom,           {.f = -1} },
-  { TERMMOD,              XK_Home,        zoomreset,      {.f =  0} },
-  { TERMMOD,              XK_C,           clipcopy,       {.i =  0} },
-  { TERMMOD,              XK_V,           clippaste,      {.i =  0} },
-  { TERMMOD,              XK_Y,           selpaste,       {.i =  0} },
-  { TERMMOD,              XK_Num_Lock,    numlock,        {.i =  0} },
-  { TERMMOD,              XK_I,           iso14755,       {.i =  0} },
+  { XK_ANY_MOD,           XK_Break,       sendbreak,      0 },
+  { ControlMask,          XK_Print,       toggleprinter,  0 },
+  { ShiftMask,            XK_Print,       printscreen,    0 },
+  { XK_ANY_MOD,           XK_Print,       printsel,       0 },
+  { TERMMOD,              XK_Prior,       zoom,           +1.f },
+  { TERMMOD,              XK_Next,        zoom,           -1.f },
+  { TERMMOD,              XK_Home,        zoomreset,      0.f },
+  { TERMMOD,              XK_C,           clipcopy,       0 },
+  { TERMMOD,              XK_V,           clippaste,      0 },
+  { TERMMOD,              XK_Y,           selpaste,       0 },
+  { TERMMOD,              XK_Num_Lock,    numlock,        0 },
+  { TERMMOD,              XK_I,           iso14755,       0 },
 };
 
 /*
@@ -192,7 +222,7 @@ Shortcut shortcuts[] = {
  * If you want keys other than the X11 function keys (0xFD00 - 0xFFFF)
  * to be mapped below, add them to this array.
  */
-static KeySym mappedkeys[] = {-1};
+static KeySym mappedkeys[] = {0 /* avoid zero-length array */};
 
 /*
  * State bits to ignore when matching key or button events.  By default,
@@ -420,7 +450,9 @@ static Key key[] = {
  * If no match is found, regular selection is used.
  */
 uint selmasks[] = {
-        [SEL_RECTANGULAR] = Mod1Mask,
+    /* none= */ 0,
+    /* SEL_REGULAR= */ 0,
+    /* SEL_RECTANGULAR= */ Mod1Mask,
 };
 
 /*

--- a/mt.cc
+++ b/mt.cc
@@ -1,19 +1,25 @@
 #include "mt.h"
 
-#include <ctype.h>
-#include <errno.h>
+#include <cctype>
+#include <cerrno>
+#include <climits>
+#include <clocale>
+#include <csignal>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <cwchar>
+
+extern "C" {
+#include <X11/Xft/Xft.h>
+#include <X11/cursorfont.h>
 #include <fcntl.h>
 #include <fontconfig/fontconfig.h>
 #include <libgen.h>
-#include <limits.h>
-#include <locale.h>
 #include <pwd.h>
-#include <signal.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sys/stat.h>
@@ -21,12 +27,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <termios.h>
-#include <time.h>
 #include <unistd.h>
-#include <wchar.h>
-
-#include <X11/Xft/Xft.h>
-#include <X11/cursorfont.h>
 
 #if defined(__linux)
 #include <pty.h>
@@ -35,6 +36,7 @@
 #elif defined(__FreeBSD__) || defined(__DragonFly__)
 #include <libutil.h>
 #endif
+}
 
 #include "x.h"
 
@@ -111,7 +113,7 @@ typedef struct {
 typedef struct {
   KeySym k;
   uint mask;
-  char *s;
+  const char *s;
   /* three valued logic variables: 0 indifferent, 1 on, -1 off */
   signed char appkey;    /* application keypad */
   signed char appcursor; /* application cursor */
@@ -149,7 +151,7 @@ static void strhandle(void);
 static void strparse(void);
 static void strreset(void);
 
-static void tprinter(char *, size_t);
+static void tprinter(const char *, size_t);
 static void tdumpsel(void);
 static void tdumpline(int);
 static void tdump(void);
@@ -194,7 +196,6 @@ static size_t utf8validate(Rune *, size_t);
 static char *base64dec(const char *);
 
 static ssize_t xwrite(int, const char *, size_t);
-static void *xrealloc(void *, size_t);
 
 /* Globals */
 TermWindow win;
@@ -246,20 +247,20 @@ ssize_t xwrite(int fd, const char *s, size_t len) {
   return aux;
 }
 
-void *xmalloc(size_t len) {
-  void *p = malloc(len);
+template <typename T> T *xmalloc(size_t len) {
+  void *p = malloc(len * sizeof(T));
 
   if (!p)
     die("Out of memory\n");
 
-  return p;
+  return static_cast<T *>(p);
 }
 
-void *xrealloc(void *p, size_t len) {
-  if ((p = realloc(p, len)) == NULL)
+template <typename T> T *xrealloc(void *p, size_t len) {
+  if ((p = realloc(p, len * sizeof(T))) == NULL)
     die("Out of memory\n");
 
-  return p;
+  return static_cast<T *>(p);
 }
 
 char *xstrdup(char *s) {
@@ -269,7 +270,7 @@ char *xstrdup(char *s) {
   return s;
 }
 
-size_t utf8decode(char *c, Rune *u, size_t clen) {
+size_t utf8decode(const char *c, Rune *u, size_t clen) {
   size_t i, j, len, type;
   Rune udecoded;
 
@@ -364,7 +365,7 @@ char *base64dec(const char *src) {
 
   if (in_len % 4)
     return NULL;
-  result = dst = xmalloc(in_len / 4 * 3 + 1);
+  result = dst = xmalloc<char>(in_len / 4 * 3 + 1);
   while (*src) {
     int a = base64_digits[(unsigned char)*src++];
     int b = base64_digits[(unsigned char)*src++];
@@ -534,7 +535,7 @@ char *getsel(void) {
     return NULL;
 
   bufsize = (term.col + 1) * (sel.ne.y - sel.nb.y + 1) * UTF_SIZ;
-  ptr = str = xmalloc(bufsize);
+  ptr = str = xmalloc<char>(bufsize);
 
   /* append every set & selected glyph to the selection */
   for (y = sel.nb.y; y <= sel.ne.y; y++) {
@@ -621,7 +622,8 @@ void execsh(void) {
     prog = utmp;
   else
     prog = sh;
-  args = (opt_cmd) ? opt_cmd : (char *[]){prog, NULL};
+  char *prog_only[] = {prog, NULL};
+  args = (opt_cmd) ? opt_cmd : prog_only;
 
   unsetenv("COLUMNS");
   unsetenv("LINES");
@@ -683,7 +685,8 @@ void stty(void) {
 
 void ttynew(void) {
   int m, s;
-  struct winsize w = {term.row, term.col, 0, 0};
+  struct winsize w = {static_cast<unsigned short>(term.row),
+                      static_cast<unsigned short>(term.col), 0, 0};
 
   if (opt_io) {
     term.mode |= MODE_PRINT;
@@ -823,9 +826,9 @@ write_error:
   die("write error on tty: %s\n", strerror(errno));
 }
 
-void ttysend(char *s, size_t n) {
+void ttysend(const char *s, size_t n) {
   int len;
-  char *t, *lim;
+  const char *t, *lim;
   Rune u;
 
   ttywrite(s, n);
@@ -911,10 +914,9 @@ void tcursor(int mode) {
 void treset(void) {
   uint i;
 
-  term.c = (TCursor){{.mode = ATTR_NULL, .fg = defaultfg, .bg = defaultbg},
-                     .x = 0,
-                     .y = 0,
-                     .state = CURSOR_DEFAULT};
+  term.c = TCursor{MTGlyph{/* rune */ 0, ATTR_NULL, defaultfg, defaultbg},
+                   /* x */ 0,
+                   /* y */ 0, CURSOR_DEFAULT};
 
   memset(term.tabs, 0, term.col * sizeof(*term.tabs));
   for (i = tabspaces; i < term.col; i += tabspaces)
@@ -934,7 +936,8 @@ void treset(void) {
 }
 
 void tnew(int col, int row) {
-  term = (Term){.c = {.attr = {.fg = defaultfg, .bg = defaultbg}}};
+  term = {};
+  term.c.attr = {/* rune */ 0, ATTR_NULL, defaultfg, defaultbg};
   tresize(col, row);
   term.numlock = 1;
 
@@ -1074,7 +1077,7 @@ void tmoveto(int x, int y) {
 }
 
 void tsetchar(Rune u, MTGlyph *attr, int x, int y) {
-  static char *vt100_0[62] = {
+  static const char *vt100_0[62] = {
       /* 0x41 - 0x7e */
       "↑", "↓", "→", "←", "█", "▚", "☃",      /* A - G */
       0,   0,   0,   0,   0,   0,   0,   0,   /* H - O */
@@ -1796,7 +1799,7 @@ void sendbreak(const Arg *arg) {
     perror("Error sending break");
 }
 
-void tprinter(char *s, size_t len) {
+void tprinter(const char *s, size_t len) {
   if (iofd != -1 && xwrite(iofd, s, len) < 0) {
     fprintf(stderr, "Error writing in %s:%s\n", opt_io, strerror(errno));
     close(iofd);
@@ -2298,24 +2301,24 @@ void tresize(int col, int row) {
   }
 
   /* resize to new width */
-  term.specbuf = xrealloc(term.specbuf, col * sizeof(XftGlyphFontSpec));
+  term.specbuf = xrealloc<XftGlyphFontSpec>(term.specbuf, col);
 
   /* resize to new height */
-  term.line = xrealloc(term.line, row * sizeof(Line));
-  term.alt = xrealloc(term.alt, row * sizeof(Line));
-  term.dirty = xrealloc(term.dirty, row * sizeof(*term.dirty));
-  term.tabs = xrealloc(term.tabs, col * sizeof(*term.tabs));
+  term.line = xrealloc<Line>(term.line, row * sizeof(Line));
+  term.alt = xrealloc<Line>(term.alt, row * sizeof(Line));
+  term.dirty = xrealloc<int>(term.dirty, row);
+  term.tabs = xrealloc<int>(term.tabs, col);
 
   /* resize each row to new width, zero-pad if needed */
   for (i = 0; i < minrow; i++) {
-    term.line[i] = xrealloc(term.line[i], col * sizeof(MTGlyph));
-    term.alt[i] = xrealloc(term.alt[i], col * sizeof(MTGlyph));
+    term.line[i] = xrealloc<MTGlyph>(term.line[i], col);
+    term.alt[i] = xrealloc<MTGlyph>(term.alt[i], col);
   }
 
   /* allocate any new rows */
   for (/* i = minrow */; i < row; i++) {
-    term.line[i] = xmalloc(col * sizeof(MTGlyph));
-    term.alt[i] = xmalloc(col * sizeof(MTGlyph));
+    term.line[i] = xmalloc<MTGlyph>(col);
+    term.alt[i] = xmalloc<MTGlyph>(col);
   }
   if (col > term.col) {
     bp = term.tabs + term.col;
@@ -2349,9 +2352,7 @@ void tresize(int col, int row) {
 }
 
 void zoom(const Arg *arg) {
-  Arg larg;
-
-  larg.f = usedfontsize + arg->f;
+  Arg larg = float(usedfontsize + arg->f);
   zoomabs(&larg);
 }
 
@@ -2365,10 +2366,8 @@ void zoomabs(const Arg *arg) {
 }
 
 void zoomreset(const Arg *arg) {
-  Arg larg;
-
   if (defaultfontsize > 0) {
-    larg.f = defaultfontsize;
+    Arg larg = float(defaultfontsize);
     zoomabs(&larg);
   }
 }
@@ -2386,7 +2385,7 @@ int match(uint mask, uint state) {
 
 void numlock(const Arg *dummy) { term.numlock ^= 1; }
 
-char *kmap(KeySym k, uint state) {
+const char *kmap(KeySym k, uint state) {
   Key *kp;
   int i;
 

--- a/mt.h
+++ b/mt.h
@@ -1,11 +1,13 @@
 #ifndef MT_MT_H
 #define MT_MT_H
 
-#include <stddef.h>
-#include <stdint.h>
-#include <time.h>
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
 
+extern "C" {
 #include <X11/Xft/Xft.h>
+}
 
 /* Arbitrary sizes */
 #define UTF_SIZ 4
@@ -135,7 +137,7 @@ typedef struct {
 typedef struct {
   uint b;
   uint mask;
-  char *s;
+  const char *s;
 } MouseShortcut;
 
 typedef struct {
@@ -161,12 +163,17 @@ typedef struct {
   // Atom xtarget;
 } Selection;
 
-typedef union {
+union Arg {
+  Arg(int val) { i = val; }
+  Arg(uint val) { i = val; }
+  Arg(float val) { f = val; }
+  Arg(const void *val) { v = val; }
+
   int i;
   uint ui;
   float f;
   const void *v;
-} Arg;
+};
 
 typedef struct {
   uint mod;
@@ -186,12 +193,12 @@ int match(uint, uint);
 void ttynew(void);
 size_t ttyread(void);
 void ttyresize(void);
-void ttysend(char *, size_t);
+void ttysend(const char *, size_t);
 void ttywrite(const char *, size_t);
 
 void resettitle(void);
 
-char *kmap(KeySym, uint);
+const char *kmap(KeySym, uint);
 void cresize(int, int);
 void selclear(void);
 
@@ -202,10 +209,9 @@ char *getsel(void);
 int x2col(int);
 int y2row(int);
 
-size_t utf8decode(char *, Rune *, size_t);
+size_t utf8decode(const char *, Rune *, size_t);
 size_t utf8encode(Rune, char *);
 
-void *xmalloc(size_t);
 char *xstrdup(char *);
 
 void usage(void);

--- a/x.cc
+++ b/x.cc
@@ -1,5 +1,14 @@
 #include "x.h"
 
+#include <algorithm>
+
+#include <cerrno>
+#include <clocale>
+#include <csignal>
+#include <cstdint>
+#include <ctime>
+
+extern "C" {
 #include <X11/XKBlib.h>
 #include <X11/Xatom.h>
 #include <X11/Xft/Xft.h>
@@ -7,14 +16,10 @@
 #include <X11/Xutil.h>
 #include <X11/cursorfont.h>
 #include <X11/keysym.h>
-#include <errno.h>
 #include <libgen.h>
-#include <locale.h>
-#include <signal.h>
-#include <stdint.h>
 #include <sys/select.h>
-#include <time.h>
 #include <unistd.h>
+}
 
 #include "arg.h"
 #include "mt.h"
@@ -77,7 +82,8 @@ typedef struct {
 static inline ushort sixd_to_16bit(int);
 static int xmakeglyphfontspecs(XftGlyphFontSpec *, const MTGlyph *, int, int,
                                int);
-static void xdrawglyphfontspecs(const XftGlyphFontSpec *, MTGlyph, int, int, int);
+static void xdrawglyphfontspecs(const XftGlyphFontSpec *, MTGlyph, int, int,
+                                int);
 static void xdrawglyph(MTGlyph, int, int);
 static void xclear(int, int, int, int);
 static void xdrawcursor(void);
@@ -104,31 +110,43 @@ static void selcopy(Time);
 static void getbuttoninfo(XEvent *);
 static void mousereport(XEvent *);
 
-static void (*handler[LASTEvent])(XEvent *) = {
-  [KeyPress] = kpress,
-  [ClientMessage] = cmessage,
-  [ConfigureNotify] = resize,
-  [VisibilityNotify] = visibility,
-  [UnmapNotify] = unmap,
-  [Expose] = expose,
-  [FocusIn] = focus,
-  [FocusOut] = focus,
-  [MotionNotify] = bmotion,
-  [ButtonPress] = bpress,
-  [ButtonRelease] = brelease,
-  /*
-   * Uncomment if you want the selection to disappear when you select something
-   * different in another window.
-   */
-  /*  [SelectionClear] = selclear_, */
-  [SelectionNotify] = selnotify,
-  /*
-   * PropertyNotify is only turned on when there is some INCR transfer happening
-   * for the selection retrieval.
-   */
-  [PropertyNotify] = propnotify,
-  [SelectionRequest] = selrequest,
-};
+void handle(XEvent *ev) {
+  switch (ev->type) {
+  case KeyPress:
+    return kpress(ev);
+  case ClientMessage:
+    return cmessage(ev);
+  case ConfigureNotify:
+    return resize(ev);
+  case VisibilityNotify:
+    return visibility(ev);
+  case UnmapNotify:
+    return unmap(ev);
+  case Expose:
+    return expose(ev);
+  case FocusIn:
+    return focus(ev);
+  case FocusOut:
+    return focus(ev);
+  case MotionNotify:
+    return bmotion(ev);
+  case ButtonPress:
+    return bpress(ev);
+  case ButtonRelease:
+    return brelease(ev);
+  // Uncomment if you want the selection to disappear when you select
+  // something different in another window.
+  //  case SelectionClear: return selclear_(ev);
+  case SelectionNotify:
+    return selnotify(ev);
+  // PropertyNotify is only turned on when there is some INCR transfer
+  // happening for the selection retrieval.
+  case PropertyNotify:
+    return propnotify(ev);
+  case SelectionRequest:
+    return selrequest(ev);
+  }
+}
 
 /* Globals */
 static DC dc;
@@ -289,7 +307,7 @@ void propnotify(XEvent *e) {
 void selnotify(XEvent *e) {
   ulong nitems, ofs, rem;
   int format;
-  uchar *data, *last, *repl;
+  uchar *data, *last;
   Atom type, incratom, property;
 
   incratom = XInternAtom(xw.dpy, "INCR", 0);
@@ -347,11 +365,8 @@ void selnotify(XEvent *e) {
      * replace all '\n' with '\r'.
      * FIXME: Fix the computer world.
      */
-    repl = data;
     last = data + nitems * format / 8;
-    while ((repl = memchr(repl, '\n', last - repl))) {
-      *repl++ = '\r';
-    }
+    std::replace(data, last, '\n', '\r');
 
     if (IS_SET(MODE_BRCKTPASTE) && ofs == 0)
       ttywrite("\033[200~", 6);
@@ -514,7 +529,8 @@ void xresize(int col, int row) {
 ushort sixd_to_16bit(int x) { return x == 0 ? 0 : 0x3737 + 0x2828 * x; }
 
 int xloadcolor(int i, const char *name, Color *ncolor) {
-  XRenderColor color = {.alpha = 0xffff};
+  XRenderColor color = {};
+  color.alpha = 0xffff;
 
   if (!name) {
     if (BETWEEN(i, 16, 255)) {  /* 256 color */
@@ -540,7 +556,9 @@ void xloadcols(void) {
   Color *cp;
 
   dc.collen = MAX(colornamelen, 256);
-  dc.col = xmalloc(dc.collen * sizeof(Color));
+  dc.col = static_cast<Color *>(malloc(dc.collen * sizeof(Color)));
+  if (!dc.col)
+    die("Out of memory\n");
 
   if (loaded) {
     for (cp = dc.col; cp < &dc.col[dc.collen]; ++cp)
@@ -581,9 +599,11 @@ void xclear(int x1, int y1, int x2, int y2) {
 }
 
 void xhints(void) {
-  XClassHint class = {opt_name ? opt_name : termname,
-                      opt_class ? opt_class : termname};
-  XWMHints wm = {.flags = InputHint, .input = 1};
+  XClassHint xclass = {opt_name ? opt_name : termname,
+                       opt_class ? opt_class : termname};
+  XWMHints wm = {};
+  wm.flags = InputHint;
+  wm.input = 1;
   XSizeHints *sizeh = NULL;
 
   sizeh = XAllocSizeHints();
@@ -607,7 +627,7 @@ void xhints(void) {
     sizeh->win_gravity = xgeommasktogravity(xw.gm);
   }
 
-  XSetWMProperties(xw.dpy, xw.win, NULL, NULL, NULL, 0, sizeh, &wm, &class);
+  XSetWMProperties(xw.dpy, xw.win, NULL, NULL, NULL, 0, sizeh, &wm, &xclass);
   XFree(sizeh);
 }
 
@@ -696,7 +716,7 @@ int xloadfont(MTFont *f, FcPattern *pattern) {
   return 0;
 }
 
-void xloadfonts(char *fontstr, double fontsize) {
+void xloadfonts(const char *fontstr, double fontsize) {
   FcPattern *pattern;
   double fontval;
   float ceilf(float);
@@ -1253,10 +1273,12 @@ void xsetenv(void) {
   setenv("WINDOWID", buf, 1);
 }
 
-void xsettitle(char *p) {
+void xsettitle(const char *p) {
   XTextProperty prop;
 
-  Xutf8TextListToTextProperty(xw.dpy, &p, 1, XUTF8StringStyle, &prop);
+  // This function only reads p, but doesn't declare it const...
+  Xutf8TextListToTextProperty(xw.dpy, const_cast<char **>(&p), 1,
+                              XUTF8StringStyle, &prop);
   XSetWMName(xw.dpy, xw.win, &prop);
   XSetTextProperty(xw.dpy, xw.win, &prop, xw.netwmname);
   XFree(prop.value);
@@ -1271,7 +1293,7 @@ void draw(void) {
 
 void drawregion(int x1, int y1, int x2, int y2) {
   int i, x, y, ox, numspecs;
-  MTGlyph base, new;
+  MTGlyph base, changed;
   XftGlyphFontSpec *specs;
   int ena_sel = sel.ob.x != -1 && sel.alt == IS_SET(MODE_ALTSCREEN);
 
@@ -1289,12 +1311,12 @@ void drawregion(int x1, int y1, int x2, int y2) {
 
     i = ox = 0;
     for (x = x1; x < x2 && i < numspecs; x++) {
-      new = term.line[y][x];
-      if (new.mode == ATTR_WDUMMY)
+      changed = term.line[y][x];
+      if (changed.mode == ATTR_WDUMMY)
         continue;
       if (ena_sel && selected(x, y))
-        new.mode ^= ATTR_REVERSE;
-      if (i > 0 && ATTRCMP(base, new)) {
+        changed.mode ^= ATTR_REVERSE;
+      if (i > 0 && ATTRCMP(base, changed)) {
         xdrawglyphfontspecs(specs, base, i, ox, y);
         specs += i;
         numspecs -= i;
@@ -1302,7 +1324,7 @@ void drawregion(int x1, int y1, int x2, int y2) {
       }
       if (i == 0) {
         ox = x;
-        base = new;
+        base = changed;
       }
       i++;
     }
@@ -1362,7 +1384,8 @@ void focus(XEvent *ev) {
 void kpress(XEvent *ev) {
   XKeyEvent *e = &ev->xkey;
   KeySym ksym;
-  char buf[32], *customkey;
+  char buf[32];
+  const char *customkey;
   int len;
   Rune c;
   Status status;
@@ -1507,8 +1530,7 @@ void run(void) {
         XNextEvent(xw.dpy, &ev);
         if (XFilterEvent(&ev, None))
           continue;
-        if (handler[ev.type])
-          (handler[ev.type])(&ev);
+        handle(&ev);
       }
 
       draw();

--- a/x.h
+++ b/x.h
@@ -1,7 +1,9 @@
 #ifndef MT_X_H
 #define MT_X_H
 
+extern "C" {
 #include <X11/Xlib.h>
+}
 
 /* X modifiers */
 #define XK_ANY_MOD UINT_MAX
@@ -19,9 +21,9 @@ void xhints(void);
 void xinit(void);
 void xloadcols(void);
 int xsetcolorname(int, const char *);
-void xloadfonts(char *, double);
+void xloadfonts(const char *, double);
 void xsetenv(void);
-void xsettitle(char *);
+void xsettitle(const char *);
 void xsetpointermotion(int);
 void xseturgency(int);
 void xunloadfonts(void);


### PR DESCRIPTION
This builds cleanly without warnings with clang++ 4.0, and gcc 4.8.4,
except for some unsigned comparison warnings which should be cleaned up.

This is a minimal set of changes, and does not attempt to be idiomatic C++.

  - update CMakeLists to build as C++ with -Wall -Werror
  - use C++ names for C stdlib headers, wrap other headers in extern "C"
  - change char* to const char* where string literals are used
  - avoid designated initializers
  - avoid compound literals
  - rename variables that collide with C++ keywords
  - make malloc wrappers typed to avoid lots of void* casts
  - replace one loop with std::replace to avoid pointer casts