### PR TITLE
Fix bug in DCS parsing: DCS is an escape state, not a mode.

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -1734,7 +1734,7 @@ void strhandle(void) {
     xsettitle(strescseq.args[0]);
     return;
   case 'P': /* DCS -- Device Control String */
-    term.mode |= ESC_DCS;
+    term.esc |= ESC_DCS;
   case '_': /* APC -- Application Program Command */
   case '^': /* PM -- Privacy Message */
     return;


### PR DESCRIPTION
Ran into this one while changing `term.mode`/`term.esc` to have the correct enum type.