### PR TITLE
Remove support for writing to a file/printer.

### DIFF
--- a/config.h
+++ b/config.h
@@ -142,9 +142,6 @@ MouseShortcut mshortcuts[] = {
 Shortcut shortcuts[] = {
   // mask                      keysym          function        argument
   { XK_ANY_MOD,                XK_Break,       sendbreak,      0 },
-  { ControlMask,               XK_Print,       toggleprinter,  0 },
-  { ShiftMask,                 XK_Print,       printscreen,    0 },
-  { XK_ANY_MOD,                XK_Print,       printsel,       0 },
   { (ControlMask | ShiftMask), XK_Prior,       zoom,           +1.f },
   { (ControlMask | ShiftMask), XK_Next,        zoom,           -1.f },
   { (ControlMask | ShiftMask), XK_Home,        zoomreset,      0.f },

--- a/mt.h
+++ b/mt.h
@@ -66,7 +66,6 @@ enum term_mode {
   MODE_MOUSEX10    = 1 << 17,
   MODE_MOUSEMANY   = 1 << 18,
   MODE_BRCKTPASTE  = 1 << 19,
-  MODE_PRINT       = 1 << 20,
   MODE_UTF8        = 1 << 21,
   MODE_SIXEL       = 1 << 22,
   MODE_MOUSE       = MODE_MOUSEBTN | MODE_MOUSEMOTION | MODE_MOUSEX10 |
@@ -226,7 +225,6 @@ extern char **opt_cmd;
 extern char *opt_class;
 extern char *opt_embed;
 extern char *opt_font;
-extern char *opt_io;
 extern char *opt_name;
 extern char *opt_title;
 extern int oldbutton;

--- a/x.cc
+++ b/x.cc
@@ -1586,9 +1586,6 @@ int main(int argc, char *argv[]) {
   case 'i':
     xw.isfixed = 1;
     break;
-  case 'o':
-    opt_io = EARGF(usage());
-    break;
   case 'n':
     opt_name = EARGF(usage());
     break;


### PR DESCRIPTION
This seems cool but:
- I'm not aware of any programs that use the MC escape sequences to
 write output to the printer (https://vt100.net/docs/vt510-rm/MC.html)
- The user-controlled modes *might* be useful for debugging, but it
seems easy to do that in a more targeted way
- There's a surprising amount of code supporting these mostly-unused features

Please push back if I'm missing something!