### PR TITLE
Simplify IO loop by buffering output, and select->poll

### DIFF
--- a/mt.cc
+++ b/mt.cc
@@ -755,7 +755,7 @@ size_t ttyread(void) {
 }
 
 void ttywrite(const char *s, size_t n) {
-  write_buffer.insert(write_buffer.begin(), s, s + n);
+  write_buffer.insert(write_buffer.end(), s, s + n);
 }
 
 void ttysend(const char *s, size_t n) {

--- a/mt.h
+++ b/mt.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <ctime>
+#include <deque>
 
 extern "C" {
 #include <X11/Xft/Xft.h>
@@ -221,6 +222,7 @@ extern TermWindow win;
 extern Term term;
 extern Selection sel;
 extern int cmdfd;
+extern std::deque<char> write_buffer;
 extern pid_t pid;
 extern char **opt_cmd;
 extern char *opt_class;

--- a/x.cc
+++ b/x.cc
@@ -1490,9 +1490,10 @@ void run(void) {
   clock_gettime(CLOCK_MONOTONIC, &last);
   lastblink = last;
 
-  std::array<pollfd, 2> poll_fds = {{pollfd{cmdfd, POLLIN, 0}, pollfd{xfd, POLLIN, 0}}};
-  pollfd& poll_cmd = poll_fds[0];
-  pollfd& poll_x = poll_fds[1];
+  std::array<pollfd, 2> poll_fds = {
+      {pollfd{cmdfd, POLLIN, 0}, pollfd{xfd, POLLIN, 0}}};
+  pollfd &poll_cmd = poll_fds[0];
+  pollfd &poll_x = poll_fds[1];
 
   for (xev = actionfps;;) {
     poll_cmd.events = POLLIN | (write_buffer.empty() ? 0 : POLLOUT);
@@ -1515,11 +1516,10 @@ void run(void) {
       std::copy(write_buffer.begin(), write_buffer.begin() + len, buf.data());
       len = write(cmdfd, buf.data(), len);
       if (len < 0) die("write error on tty: %s\n", strerror(errno));
-      write_buffer.resize(write_buffer.size() - len);
+      write_buffer.erase(write_buffer.begin(), write_buffer.begin() + len);
     }
 
-    if (poll_x.revents & POLLIN)
-      xev = actionfps;
+    if (poll_x.revents & POLLIN) xev = actionfps;
 
     clock_gettime(CLOCK_MONOTONIC, &now);
     drawtimeout.tv_sec = 0;
@@ -1550,8 +1550,7 @@ void run(void) {
       draw();
       XFlush(xw.dpy);
 
-      if (xev && !(poll_x.revents & POLLIN))
-        xev--;
+      if (xev && !(poll_x.revents & POLLIN)) xev--;
       if (!(poll_cmd.revents & POLLIN) && !(poll_x.revents & POLLIN)) {
         if (blinkset) {
           if (TIMEDIFF(now, lastblink) > blinktimeout) {

--- a/x.cc
+++ b/x.cc
@@ -1,6 +1,7 @@
 #include "x.h"
 
 #include <algorithm>
+#include <array>
 
 #include <cerrno>
 #include <clocale>
@@ -18,7 +19,7 @@ extern "C" {
 #include <X11/cursorfont.h>
 #include <X11/keysym.h>
 #include <libgen.h>
-#include <sys/select.h>
+#include <poll.h>
 #include <unistd.h>
 }
 
@@ -1462,7 +1463,6 @@ void resize(XEvent *e) {
 void run(void) {
   XEvent ev;
   int w = win.w, h = win.h;
-  fd_set rfd;
   int xfd = XConnectionNumber(xw.dpy), xev, blinkset = 0, dodraw = 0;
   struct timespec drawtimeout, *tv = NULL, now, last, lastblink;
   long deltatime;
@@ -1490,17 +1490,18 @@ void run(void) {
   clock_gettime(CLOCK_MONOTONIC, &last);
   lastblink = last;
 
-  for (xev = actionfps;;) {
-    FD_ZERO(&rfd);
-    FD_SET(cmdfd, &rfd);
-    FD_SET(xfd, &rfd);
+  std::array<pollfd, 2> poll_fds = {{pollfd{cmdfd, POLLIN, 0}, pollfd{xfd, POLLIN, 0}}};
+  pollfd& poll_cmd = poll_fds[0];
+  pollfd& poll_x = poll_fds[1];
 
-    if (pselect(MAX(xfd, cmdfd) + 1, &rfd, NULL, NULL, tv, NULL) < 0) {
+  for (xev = actionfps;;) {
+    poll_cmd.events = POLLIN | (write_buffer.empty() ? 0 : POLLOUT);
+    if (ppoll(poll_fds.data(), poll_fds.size(), tv, nullptr) < 0) {
       if (errno == EINTR)
         continue;
       die("select failed: %s\n", strerror(errno));
     }
-    if (FD_ISSET(cmdfd, &rfd)) {
+    if (poll_cmd.revents & POLLIN) {
       ttyread();
       if (blinktimeout) {
         blinkset = tattrset(ATTR_BLINK);
@@ -1508,8 +1509,16 @@ void run(void) {
           MODBIT(term.mode, 0, MODE_BLINK);
       }
     }
+    if (poll_cmd.revents & POLLOUT) {
+      static std::array<char, 256> buf;
+      int len = std::min(buf.size(), write_buffer.size());
+      std::copy(write_buffer.begin(), write_buffer.begin() + len, buf.data());
+      len = write(cmdfd, buf.data(), len);
+      if (len < 0) die("write error on tty: %s\n", strerror(errno));
+      write_buffer.resize(write_buffer.size() - len);
+    }
 
-    if (FD_ISSET(xfd, &rfd))
+    if (poll_x.revents & POLLIN)
       xev = actionfps;
 
     clock_gettime(CLOCK_MONOTONIC, &now);
@@ -1541,9 +1550,9 @@ void run(void) {
       draw();
       XFlush(xw.dpy);
 
-      if (xev && !FD_ISSET(xfd, &rfd))
+      if (xev && !(poll_x.revents & POLLIN))
         xev--;
-      if (!FD_ISSET(cmdfd, &rfd) && !FD_ISSET(xfd, &rfd)) {
+      if (!(poll_cmd.revents & POLLIN) && !(poll_x.revents & POLLIN)) {
         if (blinkset) {
           if (TIMEDIFF(now, lastblink) > blinktimeout) {
             drawtimeout.tv_nsec = 1000;


### PR DESCRIPTION
The existing code has two event loops: one with terminal reads and writes, and one with terminal and X reads.

Instead, make the terminal expose its write buffer and make a single event loop handle everything. While here, switch from select to the more elegant poll API.

Note that this means if we're writing faster than the pty can consume data, the buffer will grow without bound. But we no longer support serial lines, and ptys can do tens of MB/sec, so I think this will only happen when pasting huge text (which we put in memory anyway).

This naive buffering seems more likely to be correct than the current code where `ttyread` is reentrant, e.g. `ttyread` -> `tputc` -> `csihandle` -> `ttywrite` -> `ttyread`. I suspect bugs are lurking there.

(The timeout logic could certainly use more cleanup. Honestly I wonder whether blinking text is worth the complexity, this could be [so simple](https://github.com/sam-mccall/outermost/blob/1843b75a0a5d25e0bc136c3b4d40dfce464dc0a0/term.cc#L525-L535))